### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,9 @@
 
 name: Java CI with Maven
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/arielsrv/javalin-api/security/code-scanning/2](https://github.com/arielsrv/javalin-api/security/code-scanning/2)

To address the issue, we need to add a `permissions` block to the workflow file. Since the workflow does not seem to require write access to repository contents, the least privilege required is `contents: read`. This change ensures that the `GITHUB_TOKEN` used by the workflow has minimal access and adheres to security best practices.

The `permissions` block should be added at the root of the workflow, applying to all jobs, as the workflow does not contain individual job-specific permission requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to restrict repository access to read-only during CI runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->