### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,8 @@
 name: Docker Image CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/arielsrv/javalin-api/security/code-scanning/1](https://github.com/arielsrv/javalin-api/security/code-scanning/1)

To address the issue flagged by CodeQL, we will introduce a `permissions` block to explicitly define the minimal access level required for the job. In this case, the workflow only needs to read the repository contents to build the Docker image. Thus, we will set `contents: read` at the workflow level, as this applies to all jobs within the workflow and ensures consistency.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to explicitly set repository permissions for Docker image CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->